### PR TITLE
Fix overlapping library icon

### DIFF
--- a/src/components/home/friends/_conversation_list.scss
+++ b/src/components/home/friends/_conversation_list.scss
@@ -54,6 +54,9 @@
             &[href^="/channels/@me"]{
                 margin-left: 48px;
             }
+            &[href^="/library"]{
+                margin-left: 48px;
+            }
 
             .layout-2DM8Md{
                 height: 48px;


### PR DESCRIPTION
Tried my hand at fixing #229 

![image](https://user-images.githubusercontent.com/72220827/118297648-711c8080-b4ac-11eb-8c91-02c20c43d86c.png)
